### PR TITLE
Rename Overlap and ContainsPoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ i2 := interval.New(
   interval.UnboundedEp[Int](),
 )
 
-fmt.Println(i.Overlap(i2)) // false
+fmt.Println(i.Overlaps(i2)) // false
 ```
 - Time
 ```go
@@ -46,7 +46,7 @@ i2 := interval.New(
   interval.ClosedEp(Time(time.Date(2020, 1, 3, 0, 0, 0, 0, time.UTC))),
 )
 
-fmt.Println(i.Overlap(i2)) // true
+fmt.Println(i.Overlaps(i2)) // true
 ```
 - Other types
 ```go
@@ -77,5 +77,5 @@ i2 := interval.New(
   interval.OpenEp(ver{2, 5}),
 )
 
-fmt.Println(i.Overlap(i2)) // true
+fmt.Println(i.Overlaps(i2)) // true
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func Example() {
 			interval.UnboundedEp[Int](),
 		)
 
-		fmt.Println(i.Overlap(i2)) // false
+		fmt.Println(i.Overlaps(i2)) // false
 	}
 	// Time
 	{
@@ -42,7 +42,7 @@ func Example() {
 			interval.ClosedEp(Time(time.Date(2020, 1, 3, 0, 0, 0, 0, time.UTC))),
 		)
 
-		fmt.Println(i.Overlap(i2)) // true
+		fmt.Println(i.Overlaps(i2)) // true
 	}
 	// Custom Type
 	{
@@ -74,7 +74,7 @@ func Example() {
 			interval.OpenEp(ver{2, 5}),
 		)
 
-		fmt.Println(i.Overlap(i2)) // true
+		fmt.Println(i.Overlaps(i2)) // true
 	}
 	// Output:
 	// false

--- a/int_test.go
+++ b/int_test.go
@@ -20,8 +20,8 @@ func TestInt(t *testing.T) {
 	t.Run("IsEntire", func(t *testing.T) {
 		testIsEntire(t, Int(1))
 	})
-	t.Run("ContainsPoint", func(t *testing.T) {
-		testContainsPoint(t, Int(1), Int(2), Int(3))
+	t.Run("Contains", func(t *testing.T) {
+		testContains(t, Int(1), Int(2), Int(3))
 	})
 	t.Run("CompareInterval", func(t *testing.T) {
 		testCompareInterval(t, Int(1), Int(2), Int(3), Int(4))

--- a/interval.go
+++ b/interval.go
@@ -67,7 +67,7 @@ func (i Interval[T]) After(i2 Interval[T]) bool {
 }
 
 // True if two interval share at least one point.
-func (i Interval[T]) Overlap(i2 Interval[T]) bool {
+func (i Interval[T]) Overlaps(i2 Interval[T]) bool {
 	// empty interval never overlaps
 	if i.IsEmpty() || i2.IsEmpty() {
 		return false

--- a/interval.go
+++ b/interval.go
@@ -31,7 +31,7 @@ func (i Interval[T]) IsEntire() bool {
 }
 
 // True if interval contains given point.
-func (i Interval[T]) ContainsPoint(p T) bool {
+func (i Interval[T]) Contains(p T) bool {
 	if i.IsEmpty() {
 		return false
 	}

--- a/interval_test.go
+++ b/interval_test.go
@@ -599,7 +599,7 @@ func testCompareInterval[T Ordered[T]](t *testing.T, v1, v2, v3, v4 T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Run("overlaps", func(t *testing.T) {
-				assertEqual(t, c.overlaps, c.i.Overlap(c.i2))
+				assertEqual(t, c.overlaps, c.i.Overlaps(c.i2))
 			})
 			t.Run("before", func(t *testing.T) {
 				assertEqual(t, c.before, c.i.Before(c.i2))

--- a/interval_test.go
+++ b/interval_test.go
@@ -108,7 +108,7 @@ func testIsEntire[T Ordered[T]](t *testing.T, v T) {
 }
 
 // expect v1 < v2
-func testContainsPoint[T Ordered[T]](t *testing.T, v1, v2, v3 T) {
+func testContains[T Ordered[T]](t *testing.T, v1, v2, v3 T) {
 	unbounded := UnboundedEp[T]()
 	cases := []struct {
 		name     string
@@ -228,7 +228,7 @@ func testContainsPoint[T Ordered[T]](t *testing.T, v1, v2, v3 T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			assertEqual(t, c.want, c.interval.ContainsPoint(c.point))
+			assertEqual(t, c.want, c.interval.Contains(c.point))
 		})
 	}
 }

--- a/time_test.go
+++ b/time_test.go
@@ -25,8 +25,8 @@ func TestTime(t *testing.T) {
 	t.Run("IsEntire", func(t *testing.T) {
 		testIsEntire(t, t1)
 	})
-	t.Run("ContainsPoint", func(t *testing.T) {
-		testContainsPoint(t, t1, t2, t3)
+	t.Run("Contains", func(t *testing.T) {
+		testContains(t, t1, t2, t3)
 	})
 	t.Run("CompareInterval", func(t *testing.T) {
 		testCompareInterval(t, t1, t2, t3, t4)


### PR DESCRIPTION
- **breaking change** : rename `Interval.Overlap` to `Interval.Overlaps`
- rename `Interval.ContainsPoint` to `Interval.Contains`