### PR TITLE
rename Interval.Unbounded to Bounded

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -10,32 +10,37 @@ type Ordered[T any] interface {
 // It contains a value and a flag indicating whether it is closed and bounded.
 // The type T must have a order relation.
 type Endpoint[T Ordered[T]] struct {
-	Value   T
-	Closed  bool
-	Bounded bool
+	Value     T
+	Closed    bool
+	Unbounded bool
 }
 
 // OpenEp returns an open endpoint.
 func OpenEp[T Ordered[T]](v T) Endpoint[T] {
 	return Endpoint[T]{
-		Value:   v,
-		Closed:  false,
-		Bounded: true,
+		Value:  v,
+		Closed: false,
 	}
 }
 
 // ClosedEp returns a closed endpoint.
 func ClosedEp[T Ordered[T]](v T) Endpoint[T] {
 	return Endpoint[T]{
-		Value:   v,
-		Closed:  true,
-		Bounded: true,
+		Value:  v,
+		Closed: true,
 	}
 }
 
 // UnboundedEp returns an unbounded endpoint.
 func UnboundedEp[T Ordered[T]]() Endpoint[T] {
-	return Endpoint[T]{}
+	return Endpoint[T]{
+		Unbounded: true,
+	}
+}
+
+// Bounded is just a negation of Unbounded.
+func (e Endpoint[T]) Bounded() bool {
+	return !e.Unbounded
 }
 
 func (e Endpoint[T]) equalAndBothClosed(e2 Endpoint[T]) bool {

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -14,9 +14,9 @@ func testNewEndpoint[T Ordered[T]](t *testing.T, v T) {
 		assertEqual(
 			t,
 			Endpoint[T]{
-				Value:   v,
-				Closed:  false,
-				Bounded: true,
+				Value:     v,
+				Closed:    false,
+				Unbounded: false,
 			},
 			OpenEp(v),
 		)
@@ -25,9 +25,9 @@ func testNewEndpoint[T Ordered[T]](t *testing.T, v T) {
 		assertEqual(
 			t,
 			Endpoint[T]{
-				Value:   v,
-				Closed:  true,
-				Bounded: true,
+				Value:     v,
+				Closed:    true,
+				Unbounded: false,
 			},
 			ClosedEp(v),
 		)
@@ -36,7 +36,7 @@ func testNewEndpoint[T Ordered[T]](t *testing.T, v T) {
 		assertEqual(
 			t,
 			Endpoint[T]{
-				Bounded: false,
+				Unbounded: true,
 			},
 			UnboundedEp[T](),
 		)
@@ -121,4 +121,9 @@ func testEqualAndBothClosed[T Ordered[T]](t *testing.T, v1, v2 T) {
 			assertEqual(t, c.want, c.e.equalAndBothClosed(c.e2))
 		})
 	}
+}
+
+func TestBounded(t *testing.T) {
+	assertEqual(t, true, Endpoint[Int]{}.Bounded())
+	assertEqual(t, false, Endpoint[Int]{Unbounded: true}.Bounded())
 }

--- a/interval.go
+++ b/interval.go
@@ -2,6 +2,7 @@
 package interval
 
 // Interval represents a interval consisting of two endpoints.
+// The zero value of Interval is an empty interval.
 type Interval[T Ordered[T]] struct {
 	Lower Endpoint[T]
 	Upper Endpoint[T]

--- a/interval.go
+++ b/interval.go
@@ -17,7 +17,7 @@ func New[T Ordered[T]](lower, upper Endpoint[T]) Interval[T] {
 
 // IsEmpty returns true if no points are contained in interval.
 func (i Interval[T]) IsEmpty() bool {
-	if !i.Lower.Bounded || !i.Upper.Bounded {
+	if i.Lower.Unbounded || i.Upper.Unbounded {
 		return false
 	}
 	if i.Lower.Value.LessThan(i.Upper.Value) {
@@ -28,7 +28,7 @@ func (i Interval[T]) IsEmpty() bool {
 
 // IsEntire returns true if both endpoints are unbounded.
 func (i Interval[T]) IsEntire() bool {
-	return !i.Lower.Bounded && !i.Upper.Bounded
+	return i.Lower.Unbounded && i.Upper.Unbounded
 }
 
 // Contains returns true if interval contains the point with given value.
@@ -36,10 +36,10 @@ func (i Interval[T]) Contains(p T) bool {
 	if i.IsEmpty() {
 		return false
 	}
-	if i.Lower.Bounded && (p.LessThan(i.Lower.Value) || (p.Equal(i.Lower.Value) && !i.Lower.Closed)) {
+	if i.Lower.Bounded() && (p.LessThan(i.Lower.Value) || (p.Equal(i.Lower.Value) && !i.Lower.Closed)) {
 		return false
 	}
-	if i.Upper.Bounded && (i.Upper.Value.LessThan(p) || (p.Equal(i.Upper.Value) && !i.Upper.Closed)) {
+	if i.Upper.Bounded() && (i.Upper.Value.LessThan(p) || (p.Equal(i.Upper.Value) && !i.Upper.Closed)) {
 		return false
 	}
 	return true
@@ -50,7 +50,7 @@ func (i Interval[T]) Before(i2 Interval[T]) bool {
 	if i.IsEmpty() || i2.IsEmpty() {
 		return false
 	}
-	if i.Upper.Bounded && i2.Lower.Bounded {
+	if i.Upper.Bounded() && i2.Lower.Bounded() {
 		return i.Upper.Value.LessThan(i2.Lower.Value) || (i.Upper.Value.Equal(i2.Lower.Value) && (!i.Upper.Closed || !i2.Lower.Closed))
 	}
 	return false
@@ -61,7 +61,7 @@ func (i Interval[T]) After(i2 Interval[T]) bool {
 	if i.IsEmpty() || i2.IsEmpty() {
 		return false
 	}
-	if i2.Upper.Bounded && i.Lower.Bounded {
+	if i2.Upper.Bounded() && i.Lower.Bounded() {
 		return i2.Upper.Value.LessThan(i.Lower.Value) || (i2.Upper.Value.Equal(i.Lower.Value) && (!i2.Upper.Closed || !i.Lower.Closed))
 	}
 	return false

--- a/interval_test.go
+++ b/interval_test.go
@@ -65,6 +65,11 @@ func testIsEmpty[T Ordered[T]](t *testing.T, v1, v2 T) {
 			interval: New(OpenEp(v2), OpenEp(v1)),
 			want:     true,
 		},
+		{
+			name:     "zero interval should be empty",
+			interval: Interval[T]{},
+			want:     true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
**breaking change** : Renamed `Interval.Bounded` to `Unbounded`. This is because the zero value of the Interval type should be an empty interval rather than a entireinterval.